### PR TITLE
[README] Add installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,15 @@
 This utility assists in rapid UI development by providing component snippets from the Palette project directly in Zeplin.
 
 ![plugin preview](./assets/plugin-preview.gif)
+
+## Installation
+
+```
+$ git clone https://github.com/artsy/palette-zeplin-extension.git
+$ cd palette-zeplin-extension
+$ yarn install
+$ yarn build
+$ open dist
+```
+
+Then in Zeplin.app, open the `Extensions > Manage Project Extensions` menu. In the extensions window, hold down the <kbd>alt</kbd> key and click the `Add Local Extension` button in the top-right corner. In the modal panel, click the `Browse` button and drag the `manifest.json` file from the Finder window that was opened previously with the `open .` command.


### PR DESCRIPTION
I think that we should create GH releases and upload builds so people don’t need to `clone`, `yarn install`, and `yarn build`. In which case the instructions should get amended.

If you think the extension will rarely get updated, then the process of creating the release and uploading the asset could just be done manually.